### PR TITLE
Suggested updates to PR #43

### DIFF
--- a/src/net_components/layers/conv2d.jl
+++ b/src/net_components/layers/conv2d.jl
@@ -167,11 +167,11 @@ $(SIGNATURES)
 Computes the result of convolving `input` with the `filter` and `bias` stored in `params`.
 
 Mirrors `tf.nn.conv2d` from the `tensorflow` package, with 
-`strides = [1, params.stride, params.stride, 1]``.
+`strides = [1, params.stride, params.stride, 1]`.
 
 Supports three types of padding:
 - 'same':  Specify via `SamePadding()`. Padding is added so that the output has the same size as the input.
-- 'valid': Specify via `FixedPadding()`. No padding is added
+- 'valid': Specify via `FixedPadding()`. No padding is added.
 - 'fixed': Specify via:
   - A single integer, interpreted as padding for both axes
   - A tuple of two integers, interpreted as (y_padding, x_padding)

--- a/src/net_components/layers/conv2d.jl
+++ b/src/net_components/layers/conv2d.jl
@@ -166,15 +166,16 @@ $(SIGNATURES)
 
 Computes the result of convolving `input` with the `filter` and `bias` stored in `params`.
 
-Mirrors `tf.nn.conv2d` from the `tensorflow` package, with `strides = [1, 1, 1, 1].
+Mirrors `tf.nn.conv2d` from the `tensorflow` package, with 
+`strides = [1, params.stride, params.stride, 1]``.
 
 Supports three types of padding:
-- SamePadding(): Padding is added so that the output has the same size as the input.
-- ValidPadding(): No padding is added
-- Fixed:
-  - Int64:                             Interpreted as padding for both axes
-  - Tuple{Int64, Int64}:               Interpreted as (y_padding, x_padding)
-  - Tuple{Int64, Int64, Int64, Int64}: Interpreted as (top, bottom, left, right)
+- 'same':  Specify via `SamePadding()`. Padding is added so that the output has the same size as the input.
+- 'valid': Specify via `FixedPadding()`. No padding is added
+- 'fixed': Specify via:
+  - A single integer, interpreted as padding for both axes
+  - A tuple of two integers, interpreted as (y_padding, x_padding)
+  - A tuple of four integers, interpreted as (top, bottom, left, right)
 
 # Throws
 * AssertionError if `input` and `filter` are not compatible.

--- a/src/net_components/layers/conv2d.jl
+++ b/src/net_components/layers/conv2d.jl
@@ -2,11 +2,15 @@ using JuMP
 using ConditionalJuMP
 
 export Conv2d
-export Padding, same, valid
+export Padding, SamePadding, ValidPadding
 
-@enum DynamicPadding same=1 valid=2
-FixedPadding = Union{Int64, Tuple{Int64, Int64}, Tuple{Int64, Int64, Int64, Int64}}
-Padding = Union{DynamicPadding, FixedPadding}
+struct SamePadding end
+Base.show(io::IO, p::SamePadding) = print(io, "same")
+struct ValidPadding end
+Base.show(io::IO, p::ValidPadding) = print(io, "valid")
+
+FixedPadding = Union{Int, Tuple{Int, Int}, Tuple{Int, Int, Int, Int}}
+Padding = Union{SamePadding, ValidPadding, FixedPadding}
 
 """
 $(TYPEDEF)
@@ -42,11 +46,11 @@ function Conv2d(filter::Array{T, 4}, bias::Array{U, 1}, stride::V, padding::Padd
 end
 
 function Conv2d(filter::Array{T, 4}, bias::Array{U, 1}, stride::V) where {T<:JuMPReal, U<:JuMPReal, V<:Int64}
-    Conv2d{T, U, V}(filter, bias, stride, same)
+    Conv2d{T, U, V}(filter, bias, stride, SamePadding())
 end
 
 function Conv2d(filter::Array{T, 4}, bias::Array{U, 1}) where {T<:JuMPReal, U<:JuMPReal}
-    Conv2d(filter, bias, 1, same)
+    Conv2d(filter, bias, 1, SamePadding())
 end
 
 """
@@ -97,7 +101,65 @@ function increment!(s::JuMP.AffExpr, input_val::Real, filter_val::JuMP.Variable)
     push!(s, Float64(input_val), filter_val)
 end
 
+function compute_output_parameters(
+    in_height::Int, in_width::Int,
+    filter_height::Int, filter_width::Int, stride::Int,
+    padding::FixedPadding
+)::Tuple{NTuple{2, Int}, NTuple{2, Int}}
+    (top_padding, bottom_padding, left_padding, right_padding) = compute_padding_values(padding)
+    out_height = round(Int, (in_height + top_padding + bottom_padding - filter_height) / stride, RoundDown) + 1
+    out_width = round(Int, (in_width + left_padding + right_padding - filter_width) / stride, RoundDown) + 1
+    
+    output_size = (out_height, out_width)
+    filter_offset = (top_padding, left_padding)
+    return (output_size, filter_offset)
+end
 
+function compute_output_parameters(
+    in_height::Int, in_width::Int,
+    filter_height::Int, filter_width::Int, stride::Int,
+    padding::SamePadding
+)::Tuple{NTuple{2, Int}, NTuple{2, Int}}
+    out_height = round(Int, in_height/stride, RoundUp)
+    out_width = round(Int, in_width/stride, RoundUp)
+    pad_along_height = max((out_height - 1)*stride + filter_height - in_height, 0)
+    pad_along_width = max((out_width - 1)*stride + filter_width - in_width, 0)
+    filter_height_offset = round(Int, pad_along_height/2, RoundDown)
+    filter_width_offset = round(Int, pad_along_width/2, RoundDown)
+    
+    output_size = (out_height, out_width)
+    filter_offset = (filter_height_offset, filter_width_offset)
+    return (output_size, filter_offset)
+end
+
+function compute_output_parameters(
+    in_height::Int, in_width::Int,
+    filter_height::Int, filter_width::Int, stride::Int, 
+    padding::ValidPadding
+)::Tuple{NTuple{2, Int}, NTuple{2, Int}}
+    out_height = round(Int, (in_height + 1 - filter_height) / stride, RoundUp)
+    out_width = round(Int, (in_width + 1 - filter_width) / stride, RoundUp)
+    return((out_height, out_width), (0, 0))
+end
+
+function compute_padding_values(
+    padding::Int
+)::NTuple{4, Int}
+    return (padding, padding, padding, padding)
+end
+
+function compute_padding_values(
+    padding::NTuple{2, Int}
+)::NTuple{4, Int}
+    (y_padding, x_padding) = padding
+    return (y_padding, y_padding, x_padding, x_padding)
+end
+
+function compute_padding_values(
+    padding::NTuple{4, Int}
+)::NTuple{4, Int}
+    return padding
+end
 
 """
 $(SIGNATURES)
@@ -107,8 +169,8 @@ Computes the result of convolving `input` with the `filter` and `bias` stored in
 Mirrors `tf.nn.conv2d` from the `tensorflow` package, with `strides = [1, 1, 1, 1].
 
 Supports three types of padding:
-- 'same': Padding is added so that the output has the same size as the input.
-- 'valid': No padding is added
+- SamePadding(): Padding is added so that the output has the same size as the input.
+- ValidPadding(): No padding is added
 - Fixed:
   - Int64:                             Interpreted as padding for both axes
   - Tuple{Int64, Int64}:               Interpreted as (y_padding, x_padding)
@@ -137,45 +199,8 @@ function conv2d(
     )
 
     # Considered using offset arrays here, but could not get it working.
-
-    if padding == same
-        out_height = round(Int, in_height/stride, RoundUp)
-        out_width = round(Int, in_width/stride, RoundUp)
-        output_size = (batch, out_height, out_width, filter_out_channels)
-        pad_along_height = max((out_height - 1)*stride + filter_height - in_height, 0)
-        pad_along_width = max((out_width - 1)*stride + filter_width - in_width, 0)
-        filter_height_offset = round(Int, pad_along_height/2, RoundDown)
-        filter_width_offset = round(Int, pad_along_width/2, RoundDown)
-    elseif padding == valid
-        out_height = round(Int, (in_height + 1 - filter_height) / stride, RoundUp)
-        out_width = round(Int, (in_width + 1 - filter_width) / stride, RoundUp)
-        output_size = (batch, out_height, out_width, filter_out_channels)
-        filter_height_offset = 0
-        filter_width_offset = 0
-    elseif padding isa FixedPadding
-        if padding isa Int64
-            top_padding = padding
-            bottom_padding = padding
-            left_padding = padding
-            right_padding = padding
-        elseif padding isa Tuple{Int64, Int64}
-            (y_padding, x_padding) = padding
-            top_padding = y_padding
-            bottom_padding = y_padding
-            left_padding = x_padding
-            right_padding = x_padding
-        else
-            (top_padding, bottom_padding, left_padding, right_padding) = padding
-        end
-
-        out_height = round(Int, (in_height + top_padding + bottom_padding - filter_height) / stride, RoundDown) + 1
-        out_width = round(Int, (in_width + left_padding + right_padding - filter_width) / stride, RoundDown) + 1
-        output_size = (batch, out_height, out_width, filter_out_channels)
-        filter_height_offset = top_padding
-        filter_width_offset = left_padding
-    else
-        error("Unknown padding type $padding")
-    end
+    ((out_height, out_width), (filter_height_offset, filter_width_offset)) = compute_output_parameters(in_height, in_width, filter_height, filter_width, stride, padding)
+    output_size = (batch, out_height, out_width, filter_out_channels)
 
     W = Base.promote_op(+, V, Base.promote_op(*, T, U))
     output = Array{W}(undef, output_size)

--- a/src/utils/import_weights.jl
+++ b/src/utils/import_weights.jl
@@ -63,7 +63,7 @@ function get_conv_params(
     matrix_name::String = "weight",
     bias_name::String = "bias",
     expected_stride::Integer = 1,
-    padding::Padding = same
+    padding::Padding = SamePadding()
     )::Conv2d
 
     params = Conv2d(

--- a/test/net_components/layers/conv2d.jl
+++ b/test/net_components/layers/conv2d.jl
@@ -7,23 +7,23 @@ using MIPVerify: check_size, increment!
 function test_convolution_layer(
     p::MIPVerify.Conv2d, 
     input::AbstractArray{T, 4}, 
-    true_output::AbstractArray{T, 4}
+    expected_output::AbstractArray{T, 4}
     ) where {T<:Real}
     """
     Tests that passing `input` into the convolution layer `p` produces 
-    `true_output`. We test three combinations:
+    `expected_output`. We test three combinations:
 
       1) Passing numerical input into a numerical Conv2d layer, verifying
-         that we recover the value of `true_output`.
+         that we recover the value of `expected_output`.
 
       2) Setting up an optimization problem with variables corresponding 
          to the convolution layer and the output (`p_v` and `output_v`).
 
          `output_v` is constrained to be the result of applying `p_v` to
-         `input`, and is also constrained to be equal to `true_output`.
+         `input`, and is also constrained to be equal to `expected_output`.
 
          We verify that, when the optimization problem is solved, applying
-         `p_v` to `input` recovers the value of `true_output`.
+         `p_v` to `input` recovers the value of `expected_output`.
          
          Note that since the optimization problem is under-determined, we
          cannot assert that `p_v` is equal to `p`.
@@ -32,10 +32,10 @@ function test_convolution_layer(
          to the input and output (`input_v` and `output_v`). 
          
          `output_v` is constrained to be the result of applying `p` to 
-         `input_v`, and is also constrained to be equal to `true_output`. 
+         `input_v`, and is also constrained to be equal to `expected_output`. 
 
          We verify that, when the optimization problem is solved, applying
-         `p` to `input_v` recovers the value of `true_output`.
+         `p` to `input_v` recovers the value of `expected_output`.
 
          As in case 2), we cannot assert that `input_v` is equal to input.
     """
@@ -44,7 +44,7 @@ function test_convolution_layer(
     bias_size = size(p.bias)
     @testset "Numerical Input, Numerical Layer Parameters" begin
         evaluated_output = MIPVerify.conv2d(input, p)
-        @test evaluated_output == true_output
+        @test evaluated_output == expected_output
     end
     @testset "Numerical Input, Variable Layer Parameters" begin
         m = TestHelpers.get_new_model()
@@ -52,22 +52,22 @@ function test_convolution_layer(
         bias_v = map(_ -> @variable(m), CartesianIndices(bias_size))
         p_v = MIPVerify.Conv2d(filter_v, bias_v, p.stride, p.padding)
         output_v = MIPVerify.conv2d(input, p_v)
-        @constraint(m, output_v .== true_output)
+        @constraint(m, output_v .== expected_output)
         solve(m)
 
         p_solve = MIPVerify.Conv2d(getvalue(filter_v), getvalue(bias_v), p.stride, p.padding)
         solve_output = MIPVerify.conv2d(input, p_solve)
-        @test solve_output≈true_output
+        @test solve_output≈expected_output
     end
     @testset "Variable Input, Numerical Layer Parameters" begin
         m = TestHelpers.get_new_model()
         input_v = map(_ -> @variable(m), CartesianIndices(input_size))
         output_v = MIPVerify.conv2d(input_v, p)
-        @constraint(m, output_v .== true_output)
+        @constraint(m, output_v .== expected_output)
         solve(m)
 
         solve_output = MIPVerify.conv2d(getvalue(input_v), p)
-        @test solve_output≈true_output
+        @test solve_output≈expected_output
     end
 end
 
@@ -144,15 +144,15 @@ end
         filter_size = (3, 3, 2, 1)
         filter = reshape(collect(1:prod(filter_size)), filter_size) .- 9
         bias = [1]
-        true_output_raw = [
+        expected_output_raw = [
             225  381  405  285;
             502  787  796  532;
             550  823  832  532;
             301  429  417  249;      
         ]
-        true_output = reshape(transpose(true_output_raw), (1, 4, 4, 1))
+        expected_output = reshape(transpose(expected_output_raw), (1, 4, 4, 1))
         p = Conv2d(filter, bias)
-        test_convolution_layer(p, input, true_output)
+        test_convolution_layer(p, input, expected_output)
     end
 
     @testset "conv2d with non-unit stride" begin
@@ -162,14 +162,14 @@ end
         filter = reshape(collect(1:prod(filter_size)), filter_size) .- 9
         bias = [1]
         stride = 2
-        true_output_raw = [
+        expected_output_raw = [
             1597  1615  1120;
             1705  1723  1120;
             903   879   513 ;
         ]
-        true_output = reshape(transpose(true_output_raw), (1, 3, 3, 1))
+        expected_output = reshape(transpose(expected_output_raw), (1, 3, 3, 1))
         p = Conv2d(filter, bias, stride)
-        test_convolution_layer(p, input, true_output)
+        test_convolution_layer(p, input, expected_output)
     end
 
     @testset "conv2d with stride 2, odd input shape with even filter shape" begin
@@ -179,14 +179,14 @@ end
         filter = reshape(collect(1:prod(filter_size)), filter_size) .- 16
         bias = [1]
         stride = 2
-        true_output_raw = [
+        expected_output_raw = [
             1756  2511  1310;
             3065  4097  1969;
             1017  1225  501 ;
         ]
-        true_output = reshape(transpose(true_output_raw), (1, 3, 3, 1))
+        expected_output = reshape(transpose(expected_output_raw), (1, 3, 3, 1))
         p = Conv2d(filter, bias, stride)
-        test_convolution_layer(p, input, true_output)
+        test_convolution_layer(p, input, expected_output)
     end
 
     @testset "conv2d with 'valid' padding" begin
@@ -197,14 +197,14 @@ end
             filter = ones(filter_size...)
             bias = [0]
             stride = 1
-            true_output_raw = [
+            expected_output_raw = [
                 63 72 81;
                 108 117 126;
                 153 162 171
             ]
-            true_output = reshape(transpose(true_output_raw), (1, 3, 3, 1))
+            expected_output = reshape(transpose(expected_output_raw), (1, 3, 3, 1))
             p = Conv2d(filter, bias, stride, valid)
-            test_convolution_layer(p, input, true_output)
+            test_convolution_layer(p, input, expected_output)
         end
 
         @testset "conv2d with 'valid' padding, odd input and filter size, stride = 1, channels != 1" begin
@@ -214,14 +214,14 @@ end
             filter = ones(filter_size...)
             bias = [0]
             stride = 1
-            true_output_raw = [
+            expected_output_raw = [
                 351 369 387;
                 441 459 477;
                 531 549 567
             ]
-            true_output = reshape(transpose(true_output_raw), (1, 3, 3, 1))
+            expected_output = reshape(transpose(expected_output_raw), (1, 3, 3, 1))
             p = Conv2d(filter, bias, stride, valid)
-            test_convolution_layer(p, input, true_output)
+            test_convolution_layer(p, input, expected_output)
         end
 
         @testset "conv2d with 'valid' padding, stride = 1, input width != input height" begin
@@ -231,15 +231,15 @@ end
             filter = ones(filter_size...)
             bias = [0]
             stride = 1
-            true_output_raw = [
+            expected_output_raw = [
                 63  72  81;
                 108 117 126;
                 153 162 171;
                 198 207 216
             ]
-            true_output = reshape(transpose(true_output_raw), (1, 3, 4, 1))
+            expected_output = reshape(transpose(expected_output_raw), (1, 3, 4, 1))
             p = Conv2d(filter, bias, stride, valid)
-            test_convolution_layer(p, input, true_output)
+            test_convolution_layer(p, input, expected_output)
         end
 
         @testset "conv2d with 'valid' padding, stride=1, filter width != filter height" begin
@@ -249,15 +249,15 @@ end
             filter = ones(filter_size...)
             bias = [0]
             stride = 1
-            true_output_raw = [
+            expected_output_raw = [
                 39  45  51;
                 57  69  75;
                 81  87  99;
                 105 111 117
             ]
-            true_output = reshape(transpose(true_output_raw), (1, 4, 3, 1))
+            expected_output = reshape(transpose(expected_output_raw), (1, 4, 3, 1))
             p = Conv2d(filter, bias, stride, valid)
-            test_convolution_layer(p, input, true_output)
+            test_convolution_layer(p, input, expected_output)
         end
 
         @testset "conv2d with 'valid' padding, odd input and filter size, stride != 1" begin
@@ -267,13 +267,13 @@ end
             filter = ones(filter_size...)
             bias = [0]
             stride = 2
-            true_output_raw = [
+            expected_output_raw = [
                 63  81;
                 153 171
             ]
-            true_output = reshape(transpose(true_output_raw), (1, 2, 2, 1))
+            expected_output = reshape(transpose(expected_output_raw), (1, 2, 2, 1))
             p = Conv2d(filter, bias, stride, valid)
-            test_convolution_layer(p, input, true_output)
+            test_convolution_layer(p, input, expected_output)
         end
 
         @testset "conv2d with 'valid' padding, odd input size, even filter size, stride = 1" begin
@@ -283,15 +283,15 @@ end
             filter = ones(filter_size...)
             bias = [0]
             stride = 1
-            true_output_raw = [
+            expected_output_raw = [
                 16 20 24 28;
                 36 40 44 48;
                 56 60 64 68;
                 76 80 84 88
             ]
-            true_output = reshape(transpose(true_output_raw), (1, 4, 4, 1))
+            expected_output = reshape(transpose(expected_output_raw), (1, 4, 4, 1))
             p = Conv2d(filter, bias, stride, valid)
-            test_convolution_layer(p, input, true_output)
+            test_convolution_layer(p, input, expected_output)
         end
 
         @testset "conv2d with 'valid' padding, odd input size, even filter size, stride != 1" begin
@@ -301,13 +301,13 @@ end
             filter = ones(filter_size...)
             bias = [0]
             stride = 2
-            true_output_raw = [
+            expected_output_raw = [
                 16 24;
                 56 64
             ]
-            true_output = reshape(transpose(true_output_raw), (1, 2, 2, 1))
+            expected_output = reshape(transpose(expected_output_raw), (1, 2, 2, 1))
             p = Conv2d(filter, bias, stride, valid)
-            test_convolution_layer(p, input, true_output)
+            test_convolution_layer(p, input, expected_output)
         end
 
         @testset "conv2d with 'valid' padding, even input size, odd filter size, stride = 1" begin
@@ -317,15 +317,15 @@ end
             filter = ones(filter_size...)
             bias = [0]
             stride = 1
-            true_output_raw = [
+            expected_output_raw = [
                 72  81  90  99;
                 126 135 144 153;
                 180 189 198 207;
                 234 243 252 261
             ]
-            true_output = reshape(transpose(true_output_raw), (1, 4, 4, 1))
+            expected_output = reshape(transpose(expected_output_raw), (1, 4, 4, 1))
             p = Conv2d(filter, bias, stride, valid)
-            test_convolution_layer(p, input, true_output)
+            test_convolution_layer(p, input, expected_output)
         end
 
         @testset "conv2d with 'valid' padding, even input size, odd filter size, stride != 1" begin
@@ -335,13 +335,13 @@ end
             filter = ones(filter_size...)
             bias = [0]
             stride = 2
-            true_output_raw = [
+            expected_output_raw = [
                 72  90;
                 180 198
             ]
-            true_output = reshape(transpose(true_output_raw), (1, 2, 2, 1))
+            expected_output = reshape(transpose(expected_output_raw), (1, 2, 2, 1))
             p = Conv2d(filter, bias, stride, valid)
-            test_convolution_layer(p, input, true_output)
+            test_convolution_layer(p, input, expected_output)
         end
 
         @testset "conv2d with 'valid' padding, even input and filter size, stride = 1" begin
@@ -351,16 +351,16 @@ end
             filter = ones(filter_size...)
             bias = [0]
             stride = 1
-            true_output_raw = [
+            expected_output_raw = [
                 18  22  26  30  34;
                 42  46  50  54  58;
                 66  70  74  78  82;
                 90  94  98  102 106;
                 114 118 122 126 130
             ]
-            true_output = reshape(transpose(true_output_raw), (1, 5, 5, 1))
+            expected_output = reshape(transpose(expected_output_raw), (1, 5, 5, 1))
             p = Conv2d(filter, bias, stride, valid)
-            test_convolution_layer(p, input, true_output)
+            test_convolution_layer(p, input, expected_output)
         end
 
         @testset "conv2d with 'valid' padding, even input and filter size, stride != 1" begin
@@ -370,13 +370,13 @@ end
             filter = ones(filter_size...)
             bias = [0]
             stride = 3
-            true_output_raw = [
+            expected_output_raw = [
                 18  30;
                 90 102
             ]
-            true_output = reshape(transpose(true_output_raw), (1, 2, 2, 1))
+            expected_output = reshape(transpose(expected_output_raw), (1, 2, 2, 1))
             p = Conv2d(filter, bias, stride, valid)
-            test_convolution_layer(p, input, true_output)
+            test_convolution_layer(p, input, expected_output)
         end
     end
 
@@ -389,14 +389,14 @@ end
             bias = [0]
             stride = 1
             padding = (0, 0)
-            true_output_raw = [
+            expected_output_raw = [
                 63  72  81;
                 108 117 126;
                 153 162 171
             ]
-            true_output = reshape(transpose(true_output_raw), (1, 3, 3, 1))
+            expected_output = reshape(transpose(expected_output_raw), (1, 3, 3, 1))
             p = Conv2d(filter, bias, stride, padding)
-            test_convolution_layer(p, input, true_output)
+            test_convolution_layer(p, input, expected_output)
         end
 
         @testset "conv2d with (0, 0) padding, stride != 1" begin
@@ -407,13 +407,13 @@ end
             bias = [0]
             stride = 2
             padding = (0, 0)
-            true_output_raw = [
+            expected_output_raw = [
                 63  81;
                 153 171;
             ]
-            true_output = reshape(transpose(true_output_raw), (1, 2, 2, 1))
+            expected_output = reshape(transpose(expected_output_raw), (1, 2, 2, 1))
             p = Conv2d(filter, bias, stride, padding)
-            test_convolution_layer(p, input, true_output)
+            test_convolution_layer(p, input, expected_output)
         end
 
         @testset "conv2d with (1, 1) padding, stride = 1" begin
@@ -424,16 +424,16 @@ end
             bias = [0]
             stride = 1
             padding = (1, 1)
-            true_output_raw = [
+            expected_output_raw = [
                 16  27  33  39  28;
                 39  63  72  81  57;
                 69  108 117 126 87;
                 99  153 162 171 117;
                 76  117 123 129 88
             ]
-            true_output = reshape(transpose(true_output_raw), (1, 5, 5, 1))
+            expected_output = reshape(transpose(expected_output_raw), (1, 5, 5, 1))
             p = Conv2d(filter, bias, stride, padding)
-            test_convolution_layer(p, input, true_output)
+            test_convolution_layer(p, input, expected_output)
         end
 
         @testset "conv2d with (1, 1) padding, stride != 1" begin
@@ -444,14 +444,14 @@ end
             bias = [0]
             stride = 2
             padding = (1, 1)
-            true_output_raw = [
+            expected_output_raw = [
                 16 33  28;
                 69 117 87;
                 76 123 88
             ]
-            true_output = reshape(transpose(true_output_raw), (1, 3, 3, 1))
+            expected_output = reshape(transpose(expected_output_raw), (1, 3, 3, 1))
             p = Conv2d(filter, bias, stride, padding)
-            test_convolution_layer(p, input, true_output)
+            test_convolution_layer(p, input, expected_output)
         end
 
         @testset "conv2d with 1 padding, stride = 1" begin
@@ -462,16 +462,16 @@ end
             bias = [0]
             stride = 1
             padding = 1
-            true_output_raw = [
+            expected_output_raw = [
                 16  27  33  39  28;
                 39  63  72  81  57;
                 69  108 117 126 87;
                 99  153 162 171 117;
                 76  117 123 129 88
             ]
-            true_output = reshape(transpose(true_output_raw), (1, 5, 5, 1))
+            expected_output = reshape(transpose(expected_output_raw), (1, 5, 5, 1))
             p = Conv2d(filter, bias, stride, padding)
-            test_convolution_layer(p, input, true_output)
+            test_convolution_layer(p, input, expected_output)
         end
 
         @testset "conv2d with (1, 1) padding, input width != input_height, stride = 1" begin
@@ -482,7 +482,7 @@ end
             bias = [0]
             stride = 1
             padding = (1, 1)
-            true_output_raw = [
+            expected_output_raw = [
                 18  30  36  42  48;
                 34  45  72  81  90;
                 99  69  81  126 135;
@@ -490,9 +490,9 @@ end
                 189 198 207 141 90;
                 138 144 150 156 106
             ]
-            true_output = reshape(transpose(true_output_raw), (1, 6, 5, 1))
+            expected_output = reshape(transpose(expected_output_raw), (1, 6, 5, 1))
             p = Conv2d(filter, bias, stride, padding)
-            test_convolution_layer(p, input, true_output)
+            test_convolution_layer(p, input, expected_output)
         end
 
         @testset "conv2d with (1, 1) padding, input width != input_height, stride != 1" begin
@@ -503,14 +503,14 @@ end
             bias = [0]
             stride = 2
             padding = (1, 1)
-            true_output_raw = [
+            expected_output_raw = [
                 18  36  48;
                 81  135 153;
                 90  144 156
             ]
-            true_output = reshape(transpose(true_output_raw), (1, 3, 3, 1))
+            expected_output = reshape(transpose(expected_output_raw), (1, 3, 3, 1))
             p = Conv2d(filter, bias, stride, padding)
-            test_convolution_layer(p, input, true_output)
+            test_convolution_layer(p, input, expected_output)
         end
 
         @testset "conv2d with (1, 2) padding, stride = 1" begin
@@ -521,7 +521,7 @@ end
             bias = [0]
             stride = 1
             padding = (1, 2)
-            true_output_raw = [
+            expected_output_raw = [
                 3   6   9   12  9;
                 16  27  33  39  28;
                 39  63  72  81  57;
@@ -530,9 +530,9 @@ end
                 76  117 123 129 88;
                 43  66  69  72  49
             ]
-            true_output = reshape(transpose(true_output_raw), (1, 5, 7, 1))
+            expected_output = reshape(transpose(expected_output_raw), (1, 5, 7, 1))
             p = Conv2d(filter, bias, stride, padding)
-            test_convolution_layer(p, input, true_output)
+            test_convolution_layer(p, input, expected_output)
         end
 
         @testset "conv2d with (1, 2) padding, stride != 1" begin
@@ -543,15 +543,15 @@ end
             bias = [0]
             stride = 2
             padding = (1, 2)
-            true_output_raw = [
+            expected_output_raw = [
                3   9   9;
                39  72  57;
                99  162 117;
                43  69  49
             ]
-            true_output = reshape(transpose(true_output_raw), (1, 3, 4, 1))
+            expected_output = reshape(transpose(expected_output_raw), (1, 3, 4, 1))
             p = Conv2d(filter, bias, stride, padding)
-            test_convolution_layer(p, input, true_output)
+            test_convolution_layer(p, input, expected_output)
         end
 
         @testset "conv2d with (1, 1) padding, channels != 1, stride = 1" begin
@@ -562,16 +562,16 @@ end
             bias = [0]
             stride = 1
             padding = (1, 1)
-            true_output_raw = [
+            expected_output_raw = [
                 132 204 216 228 156;
                 228 351 369 387 264;
                 288 441 459 477 324;
                 348 531 549 567 384;
                 252 384 396 408 276
             ]
-            true_output = reshape(transpose(true_output_raw), (1, 5, 5, 1))
+            expected_output = reshape(transpose(expected_output_raw), (1, 5, 5, 1))
             p = Conv2d(filter, bias, stride, padding)
-            test_convolution_layer(p, input, true_output)
+            test_convolution_layer(p, input, expected_output)
         end
 
         @testset "conv2d with (1, 1) padding, channels != 1, stride != 1" begin
@@ -582,14 +582,14 @@ end
             bias = [0]
             stride = 2
             padding = (1, 1)
-            true_output_raw = [
+            expected_output_raw = [
                 132 216 156;
                 288 459 324;
                 252 396 276
             ]
-            true_output = reshape(transpose(true_output_raw), (1, 3, 3, 1))
+            expected_output = reshape(transpose(expected_output_raw), (1, 3, 3, 1))
             p = Conv2d(filter, bias, stride, padding)
-            test_convolution_layer(p, input, true_output)
+            test_convolution_layer(p, input, expected_output)
         end
 
         @testset "conv2d with (1, 1, 1, 1) padding, stride = 1" begin
@@ -600,16 +600,16 @@ end
             bias = [0]
             stride = 1
             padding = (1, 1, 1, 1)
-            true_output_raw = [
+            expected_output_raw = [
                 16  27  33  39  28;
                 39  63  72  81  57;
                 69  108 117 126 87;
                 99  153 162 171 117;
                 76  117 123 129 88
             ]
-            true_output = reshape(transpose(true_output_raw), (1, 5, 5, 1))
+            expected_output = reshape(transpose(expected_output_raw), (1, 5, 5, 1))
             p = Conv2d(filter, bias, stride, padding)
-            test_convolution_layer(p, input, true_output)
+            test_convolution_layer(p, input, expected_output)
         end
 
         @testset "conv2d with (1, 2, 3, 4) padding, stride = 1" begin
@@ -620,7 +620,7 @@ end
             bias = [0]
             stride = 1
             padding = (1, 2, 3, 4)
-            true_output_raw = [
+            expected_output_raw = [
                0   0   0   0   0   0;
                3   6   9  12   9   5
                16  27  33  39  28  15;
@@ -632,9 +632,9 @@ end
                0   0   0   0   0   0;
                0   0   0   0   0   0
             ]
-            true_output = reshape(transpose(true_output_raw), (1, 6, 10, 1))
+            expected_output = reshape(transpose(expected_output_raw), (1, 6, 10, 1))
             p = Conv2d(filter, bias, stride, padding)
-            test_convolution_layer(p, input, true_output)
+            test_convolution_layer(p, input, expected_output)
         end
     end
 end

--- a/test/net_components/layers/conv2d.jl
+++ b/test/net_components/layers/conv2d.jl
@@ -228,7 +228,7 @@ end
                 (3, 3, 1, 1),
                 transpose(expected_output_2d),
                 1,
-                valid
+                ValidPadding()
             )
         end
 
@@ -243,7 +243,7 @@ end
                 (3, 3, 2, 1),
                 transpose(expected_output_2d),
                 1,
-                valid
+                ValidPadding()
             )
         end
 
@@ -259,7 +259,7 @@ end
                 (3, 3, 1, 1),
                 transpose(expected_output_2d),
                 1,
-                valid
+                ValidPadding()
             )
         end
 
@@ -274,7 +274,7 @@ end
                 (2, 3, 1, 1),
                 transpose(expected_output_2d),
                 1,
-                valid
+                ValidPadding()
             )
         end
 
@@ -288,7 +288,7 @@ end
                 (3, 3, 1, 1),
                 transpose(expected_output_2d),
                 2,
-                valid
+                ValidPadding()
             )
         end
 
@@ -304,7 +304,7 @@ end
                 (2, 2, 1, 1),
                 transpose(expected_output_2d),
                 1,
-                valid
+                ValidPadding()
             )
         end
 
@@ -318,7 +318,7 @@ end
                 (2, 2, 1, 1),
                 transpose(expected_output_2d),
                 2,
-                valid
+                ValidPadding()
             )
         end
 
@@ -334,7 +334,7 @@ end
                 (3, 3, 1, 1),
                 transpose(expected_output_2d),
                 1,
-                valid
+                ValidPadding()
             )
         end
 
@@ -348,7 +348,7 @@ end
                 (3, 3, 1, 1),
                 transpose(expected_output_2d),
                 2,
-                valid
+                ValidPadding()
             )
         end
 
@@ -365,7 +365,7 @@ end
                 (2, 2, 1, 1),
                 transpose(expected_output_2d),
                 1,
-                valid
+                ValidPadding()
             )
         end
 
@@ -379,7 +379,7 @@ end
                 (2, 2, 1, 1),
                 transpose(expected_output_2d),
                 3,
-                valid
+                ValidPadding()
             )
         end
     end

--- a/test/net_components/layers/conv2d.jl
+++ b/test/net_components/layers/conv2d.jl
@@ -15,7 +15,7 @@ function test_convolution_layer(
 
       1) Passing numerical input into a numerical Conv2d layer, verifying
          that we recover the value of `true_output`.
-         
+
       2) Setting up an optimization problem with variables corresponding 
          to the convolution layer and the output (`p_v` and `output_v`).
 
@@ -143,7 +143,6 @@ end
         input = reshape(collect(1:prod(input_size)), input_size) .- 16
         filter_size = (3, 3, 2, 1)
         filter = reshape(collect(1:prod(filter_size)), filter_size) .- 9
-        bias_size = (1, )
         bias = [1]
         true_output_raw = [
             225  381  405  285;
@@ -161,7 +160,6 @@ end
         input = reshape(collect(1:prod(input_size)), input_size) .- 36
         filter_size = (3, 3, 2, 1)
         filter = reshape(collect(1:prod(filter_size)), filter_size) .- 9
-        bias_size = (1, )
         bias = [1]
         stride = 2
         true_output_raw = [
@@ -179,7 +177,6 @@ end
         input = reshape(collect(1:prod(input_size)), input_size) .- 25
         filter_size = (4, 4, 2, 1)
         filter = reshape(collect(1:prod(filter_size)), filter_size) .- 16
-        bias_size = (1, )
         bias = [1]
         stride = 2
         true_output_raw = [
@@ -198,7 +195,6 @@ end
             input = reshape([1:prod(input_size);], input_size)
             filter_size = (3, 3, 1, 1)
             filter = ones(filter_size...)
-            bias_size = (1, )
             bias = [0]
             stride = 1
             true_output_raw = [
@@ -216,7 +212,6 @@ end
             input = reshape([1:prod(input_size);], input_size)
             filter_size = (3, 3, 2, 1)
             filter = ones(filter_size...)
-            bias_size = (1, )
             bias = [0]
             stride = 1
             true_output_raw = [
@@ -234,7 +229,6 @@ end
             input = reshape([1:prod(input_size);], input_size)
             filter_size = (3, 3, 1, 1)
             filter = ones(filter_size...)
-            bias_size = (1, )
             bias = [0]
             stride = 1
             true_output_raw = [
@@ -253,7 +247,6 @@ end
             input = reshape([1:prod(input_size);], input_size)
             filter_size = (2, 3, 1, 1)
             filter = ones(filter_size...)
-            bias_size = (1, )
             bias = [0]
             stride = 1
             true_output_raw = [
@@ -272,7 +265,6 @@ end
             input = reshape([1:prod(input_size);], input_size)
             filter_size = (3, 3, 1, 1)
             filter = ones(filter_size...)
-            bias_size = (1, )
             bias = [0]
             stride = 2
             true_output_raw = [
@@ -289,7 +281,6 @@ end
             input = reshape([1:prod(input_size);], input_size)
             filter_size = (2, 2, 1, 1)
             filter = ones(filter_size...)
-            bias_size = (1, )
             bias = [0]
             stride = 1
             true_output_raw = [
@@ -308,7 +299,6 @@ end
             input = reshape([1:prod(input_size);], input_size)
             filter_size = (2, 2, 1, 1)
             filter = ones(filter_size...)
-            bias_size = (1, )
             bias = [0]
             stride = 2
             true_output_raw = [
@@ -325,7 +315,6 @@ end
             input = reshape([1:prod(input_size);], input_size)
             filter_size = (3, 3, 1, 1)
             filter = ones(filter_size...)
-            bias_size = (1, )
             bias = [0]
             stride = 1
             true_output_raw = [
@@ -344,7 +333,6 @@ end
             input = reshape([1:prod(input_size);], input_size)
             filter_size = (3, 3, 1, 1)
             filter = ones(filter_size...)
-            bias_size = (1, )
             bias = [0]
             stride = 2
             true_output_raw = [
@@ -361,7 +349,6 @@ end
             input = reshape([1:prod(input_size);], input_size)
             filter_size = (2, 2, 1, 1)
             filter = ones(filter_size...)
-            bias_size = (1, )
             bias = [0]
             stride = 1
             true_output_raw = [
@@ -381,7 +368,6 @@ end
             input = reshape([1:prod(input_size);], input_size)
             filter_size = (2, 2, 1, 1)
             filter = ones(filter_size...)
-            bias_size = (1, )
             bias = [0]
             stride = 3
             true_output_raw = [
@@ -400,7 +386,6 @@ end
             input = reshape([1:prod(input_size);], input_size)
             filter_size = (3, 3, 1, 1)
             filter = ones(filter_size...)
-            bias_size = (1, )
             bias = [0]
             stride = 1
             padding = (0, 0)
@@ -419,7 +404,6 @@ end
             input = reshape([1:prod(input_size);], input_size)
             filter_size = (3, 3, 1, 1)
             filter = ones(filter_size...)
-            bias_size = (1, )
             bias = [0]
             stride = 2
             padding = (0, 0)
@@ -437,7 +421,6 @@ end
             input = reshape([1:prod(input_size);], input_size)
             filter_size = (3, 3, 1, 1)
             filter = ones(filter_size...)
-            bias_size = (1, )
             bias = [0]
             stride = 1
             padding = (1, 1)
@@ -458,7 +441,6 @@ end
             input = reshape([1:prod(input_size);], input_size)
             filter_size = (3, 3, 1, 1)
             filter = ones(filter_size...)
-            bias_size = (1, )
             bias = [0]
             stride = 2
             padding = (1, 1)
@@ -477,7 +459,6 @@ end
             input = reshape([1:prod(input_size);], input_size)
             filter_size = (3, 3, 1, 1)
             filter = ones(filter_size...)
-            bias_size = (1, )
             bias = [0]
             stride = 1
             padding = 1
@@ -498,7 +479,6 @@ end
             input = reshape([1:prod(input_size);], input_size)
             filter_size = (3, 3, 1, 1)
             filter = ones(filter_size...)
-            bias_size = (1, )
             bias = [0]
             stride = 1
             padding = (1, 1)
@@ -520,7 +500,6 @@ end
             input = reshape([1:prod(input_size);], input_size)
             filter_size = (3, 3, 1, 1)
             filter = ones(filter_size...)
-            bias_size = (1, )
             bias = [0]
             stride = 2
             padding = (1, 1)
@@ -539,7 +518,6 @@ end
             input = reshape([1:prod(input_size);], input_size)
             filter_size = (3, 3, 1, 1)
             filter = ones(filter_size...)
-            bias_size = (1, )
             bias = [0]
             stride = 1
             padding = (1, 2)
@@ -562,7 +540,6 @@ end
             input = reshape([1:prod(input_size);], input_size)
             filter_size = (3, 3, 1, 1)
             filter = ones(filter_size...)
-            bias_size = (1, )
             bias = [0]
             stride = 2
             padding = (1, 2)
@@ -582,7 +559,6 @@ end
             input = reshape([1:prod(input_size);], input_size)
             filter_size = (3, 3, 2, 1)
             filter = ones(filter_size...)
-            bias_size = (1, )
             bias = [0]
             stride = 1
             padding = (1, 1)
@@ -603,7 +579,6 @@ end
             input = reshape([1:prod(input_size);], input_size)
             filter_size = (3, 3, 2, 1)
             filter = ones(filter_size...)
-            bias_size = (1, )
             bias = [0]
             stride = 2
             padding = (1, 1)
@@ -622,7 +597,6 @@ end
             input = reshape([1:prod(input_size);], input_size)
             filter_size = (3, 3, 1, 1)
             filter = ones(filter_size...)
-            bias_size = (1, )
             bias = [0]
             stride = 1
             padding = (1, 1, 1, 1)
@@ -643,7 +617,6 @@ end
             input = reshape([1:prod(input_size);], input_size)
             filter_size = (3, 3, 1, 1)
             filter = ones(filter_size...)
-            bias_size = (1, )
             bias = [0]
             stride = 1
             padding = (1, 2, 3, 4)


### PR DESCRIPTION
Thank you for your PR! I really, really appreciate the thorough testing.

I had some suggested changes and started typing them up in comments, but realized that the amount of code change required was rather large, so I went ahead and made a copy of your branch and made some changes on top of that. Here are the main things I modified:

In `test/net_components/layers/conv2d.jl`:
  + Unified logic for three different types of tests in `test_convolution_layer` to avoid duplication. 
  + Unified logic for the new tests cases that you added in `test_convolution_layer_with_default_values`. (This also required me changing the `real_output_raw` in two of the tests; it appears that the `real_output_raw` was initiall wrong but the resulting `real_output` was correct after reshaping.)
  + Rename: 
    + `real_output` -> `expected_output`
    + `real_output_raw` -> `expected_output_2d`.

In `src/net_components/layers/conv2d.jl`:
  + Switched `DynamicPadding` enum into two seperate [singleton types](https://docs.julialang.org/en/v1/manual/types/#Composite-Types-1). This is a bit annoying from the user's point of view, (since they now have to call `SamePadding()` rather than just `same`, but provides the benefit that we can now extract the logic of to compute the value of `out_height, out_width, filter_height_offset, filter_width_offset` into three functions (`compute_output_parameters`) specialized on the type.
  + Specified `FixedPadding` using `Int` rather than `Int64` (`Int64` is a subtype of `Int`). 
  + Modified documentation for `conv2d`.

Let me know what you think of these changes. If you're comfortable, you can merge it into your master branch, and then I can merge https://github.com/vtjeng/MIPVerify.jl/pull/43 with those changes. 

Just to make sure, I'm running tests in https://github.com/vtjeng/MIPVerify.jl/pull/44 to ensure that the tests all still pass.
